### PR TITLE
fix exception when only downloading small images

### DIFF
--- a/src/Assembly/Helpers/Net/BlamCacheMetaData.cs
+++ b/src/Assembly/Helpers/Net/BlamCacheMetaData.cs
@@ -164,7 +164,7 @@ namespace Assembly.Helpers.Net
 
 				if (!downloadLarge && !downloadSmall) continue;
 
-				var imageDirectory = Path.GetDirectoryName(localPath);
+				var imageDirectory = Path.GetDirectoryName(localPath == "" ? localPathSmall : localPath);
 				if (imageDirectory == null) continue;
 
 				if (!Directory.Exists(imageDirectory))


### PR DESCRIPTION
..., thus exception. So just use localPathSmall in that case.

Signed-off-by: Connor Tumbleson connor.tumbleson@gmail.com
