### PR TITLE
Fix resizing

### DIFF
--- a/src/Assembly/Windows/Home.xaml
+++ b/src/Assembly/Windows/Home.xaml
@@ -159,23 +159,34 @@
 			</Grid>
 
 			<Grid Margin="-1, -1, -1, -23" x:Name="homeResizing">
-				<!--Resize-->
-				<!--Corner-->
+				<!--Grip-->
 				<Vectors:ResizeModule x:Name="ResizeDropVector" VerticalAlignment="Bottom" HorizontalAlignment="Right"
-				                      Margin="0,0,5,5" Cursor="SizeNWSE" />
-				<Thumb x:Name="ResizeDrop" DragDelta="ResizeDrop_DragDelta" Opacity="0" Background="{x:Null}" Foreground="{x:Null}"
-				       Width="11" Height="11" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,1,1"
-				       Cursor="SizeNWSE" />
+									  Margin="0,0,5,5" Cursor="SizeNWSE" />
 
-				<!--Side-->
+				<!--Corner-->
+				<Thumb x:Name="ResizeDrop" DragDelta="ResizeDrop_DragDelta" Opacity="0" Background="{x:Null}" Foreground="{x:Null}"
+					   Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,1,1"
+					   Cursor="SizeNWSE" />
+
+				<!--Right-->
 				<Thumb x:Name="ResizeRight" DragDelta="ResizeRight_DragDelta" Opacity="0" Background="{x:Null}"
-				       Foreground="{x:Null}" Width="8" Margin="0,27.333,0,11" HorizontalAlignment="Right"
-				       VerticalAlignment="Stretch" Cursor="SizeWE" />
+					   Foreground="{x:Null}" Width="8" Margin="0,27.333,0,11" HorizontalAlignment="Right"
+					   VerticalAlignment="Stretch" Cursor="SizeWE" />
 
 				<!--Bottom-->
 				<Thumb x:Name="ResizeBottom" DragDelta="ResizeBottom_DragDelta" Opacity="0" Background="{x:Null}"
-				       Foreground="{x:Null}" Height="8" Margin="0,0,11,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
-				       Cursor="SizeNS" />
+					   Foreground="{x:Null}" Height="8" Margin="0,0,11,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+					   Cursor="SizeNS" />
+
+				<!--Left-->
+				<Thumb x:Name="ResizeLeft" DragDelta="ResizeLeft_DragDelta" Opacity="0" Background="{x:Null}"
+					   Foreground="{x:Null}" Width="8" Margin="0,27.333,0,11" HorizontalAlignment="Left"
+					   VerticalAlignment="Stretch" Cursor="SizeWE" />
+
+				<!--Top-->
+				<Thumb x:Name="ResizeTop" DragDelta="ResizeTop_DragDelta" Opacity="0" Background="{x:Null}"
+					   Foreground="{x:Null}" Height="8" Margin="0,0,11,0" HorizontalAlignment="Stretch" VerticalAlignment="Top"
+					   Cursor="SizeNS" />
 			</Grid>
 
 			<Rectangle x:Name="OpacityRect" Opacity="0.65" Fill="{DynamicResource HomeOpacityBrush}" Visibility="Collapsed" />

--- a/src/Assembly/Windows/Home.xaml.cs
+++ b/src/Assembly/Windows/Home.xaml.cs
@@ -239,8 +239,13 @@ namespace Assembly.Windows
 
 			if (xadjust > MinWidth)
 				Width = xadjust;
+			else
+				Width = MinWidth;
+
 			if (yadjust > MinHeight)
 				Height = yadjust;
+			else
+				Height = MinHeight;
 		}
 
 		private void ResizeRight_DragDelta(object sender, DragDeltaEventArgs e)
@@ -249,6 +254,8 @@ namespace Assembly.Windows
 
 			if (xadjust > MinWidth)
 				Width = xadjust;
+			else
+				Width = MinWidth;
 		}
 
 		private void ResizeBottom_DragDelta(object sender, DragDeltaEventArgs e)
@@ -257,6 +264,34 @@ namespace Assembly.Windows
 
 			if (yadjust > MinHeight)
 				Height = yadjust;
+			else
+				Height = MinHeight;
+		}
+
+		private void ResizeLeft_DragDelta(object sender, DragDeltaEventArgs e)
+		{
+			double xadjust = Width - e.HorizontalChange;
+
+			if (xadjust > MinWidth)
+			{
+				Width = xadjust;
+				Left += e.HorizontalChange;
+			}
+			else
+				Width = MinWidth;
+		}
+
+		private void ResizeTop_DragDelta(object sender, DragDeltaEventArgs e)
+		{
+			double yadjust = Height - e.VerticalChange;
+
+			if (yadjust > MinHeight)
+			{
+				Height = yadjust;
+				Top += e.VerticalChange;
+			}
+			else
+				Height = MinHeight;
 		}
 
 		private void Window_StateChanged(object sender, EventArgs e)


### PR DESCRIPTION
##### Allow resizing from top and left

Only the two edges were added. No additional corner resize grips were added.
##### Enlarge grip in bottom corner

This was really hard to use with a stylus on my Surface, so I increased it from 11x11 pixels to 22x22.
##### Fix subtle resizing bug

When resizing very quickly, sometimes the mouse moves too far before the app finishes resizing. Adding fallthrough else-clauses to ResizeDrop_DragDelta, ResizeRight_DragDelta, and ResizeBottom_DragDelta fixes this.
