### PR TITLE
Allow resizing from top and left; Enlarge grip in bottom corner; ...

### DIFF
--- a/src/Atlas/Metro/Controls/Custom/MetroWindow.cs
+++ b/src/Atlas/Metro/Controls/Custom/MetroWindow.cs
@@ -71,9 +71,22 @@ namespace Atlas.Metro.Controls.Custom
 			var xAdjust = Width + e.HorizontalChange;
 
 			if (xAdjust > MinWidth)
+			{
 				Width = xAdjust;
+			}
+			else
+			{
+				Width = MinWidth;
+			}
+
 			if (yAdjust > MinHeight)
+			{
 				Height = yAdjust;
+			}
+			else
+			{
+				Height = MinHeight;
+			}
 		}
 
 		public void ResizeRightThumb_OnDragDelta(object sender, DragDeltaEventArgs e)
@@ -81,7 +94,13 @@ namespace Atlas.Metro.Controls.Custom
 			var xAdjust = Width + e.HorizontalChange;
 
 			if (xAdjust > MinWidth)
+			{
 				Width = xAdjust;
+			}
+			else
+			{
+				Width = MinWidth;
+			}
 		}
 
 		public void ResizeBottomThumb_OnDragDelta(object sender, DragDeltaEventArgs e)
@@ -89,7 +108,63 @@ namespace Atlas.Metro.Controls.Custom
 			var yAdjust = Height + e.VerticalChange;
 
 			if (yAdjust > MinHeight)
+			{
 				Height = yAdjust;
+			}
+			else
+			{
+				Height = MinHeight;
+			}
+		}
+
+		public void ResizeLeftThumb_OnDragDelta(object sender, DragDeltaEventArgs e)
+		{
+			var xAdjust = Width - e.HorizontalChange;
+
+			if (xAdjust > MinWidth)
+			{
+				Width -= e.HorizontalChange;
+				Left += e.HorizontalChange;
+			}
+			else
+			{
+				var diff = Width - MinWidth;
+				if (diff > 0)
+				{
+					Width -= diff;  // Width = MinWidth
+					Left += diff;   // mirror that^ change
+				}
+				else
+				{
+					Width += diff;  // Width = MinWidth
+					Left -= diff;   // mirror that^ change
+				}
+			}
+		}
+
+		public void ResizeTopThumb_OnDragDelta(object sender, DragDeltaEventArgs e)
+		{
+			var yAdjust = Height - e.VerticalChange;
+
+			if (yAdjust > MinHeight)
+			{
+				Height -= e.VerticalChange;
+				Top += e.VerticalChange;
+			}
+			else
+			{
+				var diff = Height - MinHeight;
+				if (diff > 0)
+				{
+					Height -= diff; // Height = MinHeight
+					Top += diff;	// mirror that^ change
+				}
+				else
+				{
+					Height += diff; // Height = MinHeight
+					Top -= diff;	// mirror that^ change
+				}
+			}
 		}
 
 		#endregion

--- a/src/Atlas/Windows/Home.xaml
+++ b/src/Atlas/Windows/Home.xaml
@@ -36,7 +36,7 @@
 														  Margin="0,0,5,5" />
 									
 									<Thumb x:Name="ResizeCornerThumb" Opacity="0" Background="{x:Null}" 
-										   Foreground="{x:Null}" Width="11" Height="11" Margin="0,0,1,1"
+										   Foreground="{x:Null}" Width="22" Height="22" Margin="0,0,1,1"
 										   HorizontalAlignment="Right" VerticalAlignment="Bottom" Cursor="SizeNWSE">
 										<Thumb.Style>
 											<Style TargetType="{x:Type Thumb}">
@@ -55,12 +55,32 @@
 										</Thumb.Style>
 									</Thumb>
 
+									<Thumb x:Name="ResizeLeftThumb" Opacity="0" Background="{x:Null}" 
+										   Foreground="{x:Null}" Width="8" Margin="0,28,0,11"
+										   HorizontalAlignment="Left" VerticalAlignment="Stretch" Cursor="SizeWE">
+										<Thumb.Style>
+											<Style TargetType="{x:Type Thumb}">
+												<EventSetter Event="DragDelta" Handler="ResizeLeftThumb_OnDragDelta" />
+											</Style>
+										</Thumb.Style>
+									</Thumb>
+
 									<Thumb x:Name="ResizeBottomThumb" Opacity="0" Background="{x:Null}" 
 										   Foreground="{x:Null}" Height="8" Margin="0,0,11,0"
 										   HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Cursor="SizeNS">
 										<Thumb.Style>
 											<Style TargetType="{x:Type Thumb}">
 												<EventSetter Event="DragDelta" Handler="ResizeBottomThumb_OnDragDelta" />
+											</Style>
+										</Thumb.Style>
+									</Thumb>
+
+									<Thumb x:Name="ResizeTopThumb" Opacity="0" Background="{x:Null}" 
+										   Foreground="{x:Null}" Height="8" Margin="0,0,11,0"
+										   HorizontalAlignment="Stretch" VerticalAlignment="Top" Cursor="SizeNS">
+										<Thumb.Style>
+											<Style TargetType="{x:Type Thumb}">
+												<EventSetter Event="DragDelta" Handler="ResizeTopThumb_OnDragDelta" />
 											</Style>
 										</Thumb.Style>
 									</Thumb>


### PR DESCRIPTION
Resubmitting my pull request against the atlas branch.
### Summary of Changes
##### Allow resizing from top and left

Only the two edges were added. No additional corner resize grips were added.
##### Enlarge grip in bottom corner

This was really hard to use with a stylus on my Surface, so I increased it from 11x11 pixels to 22x22.
##### Fix subtle resizing bugs

When resizing very quickly, sometimes the mouse moves too far before the app finishes resizing. Adding fallthrough else-clauses to the drop handlers fixes this.
