### PR TITLE
Always prompt for administrator access

### DIFF
--- a/src/Assembly/Properties/app.manifest
+++ b/src/Assembly/Properties/app.manifest
@@ -3,6 +3,14 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
 
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="true" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of all Windows versions that this application is designed to work with. 


### PR DESCRIPTION
This prevents confusing "cannot read the registry" errors. See #184 