### PR TITLE
Add KeyboardNavigation.TabNavigation="Cycle" to panelMetaComponents

### DIFF
--- a/src/Assembly/Metro/Controls/PageTemplates/Games/Components/MetaEditor.xaml
+++ b/src/Assembly/Metro/Controls/PageTemplates/Games/Components/MetaEditor.xaml
@@ -60,7 +60,7 @@
 			</Border>
 		</Grid>
 		<Grid Grid.Row="1">
-			<ListBox Name="panelMetaComponents" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+			<ListBox Name="panelMetaComponents" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" KeyboardNavigation.TabNavigation="Cycle"
 		         VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Standard"
 		         ScrollViewer.CanContentScroll="True"
 		         SelectionChanged="panelMetaComponents_SelectionChanged_1">


### PR DESCRIPTION
Enables the use of the TAB key to navigate to the next item in the tag editor.