### PR TITLE
Add missing parameter to Multi4Data constructor

### DIFF
--- a/src/Assembly/Metro/Controls/PageTemplates/Games/Components/MetaData/MultiData.cs
+++ b/src/Assembly/Metro/Controls/PageTemplates/Games/Components/MetaData/MultiData.cs
@@ -115,6 +115,7 @@ namespace Assembly.Metro.Controls.PageTemplates.Games.Components.MetaData
 			_a = a;
 			_b = b;
 			_c = c;
+			_d = d;
 		}
 
 		public string Type


### PR DESCRIPTION
Not sure if this was intentional, but the fourth parameter for the Multi4Data class was missing inside the constructor.